### PR TITLE
bugfix: fatal error on sync orders

### DIFF
--- a/Controller/Index/Index.php
+++ b/Controller/Index/Index.php
@@ -2154,7 +2154,7 @@ class Index extends \Magento\Framework\App\Action\Action
 
         if($customer){
             $checkoutSession = $this->session;
-            $checkoutSession->setCustomer($customer);
+            $checkoutSession->setCustomerData($customer);
             $checkoutSession->replaceQuote($quote);
             $checkoutSession->setData('customer_comment', $customerInstruction);
             $checkoutSession->setData('destination_type', 'residence');


### PR DESCRIPTION
Magento 2.2.6 bugfix:
`PHP Fatal error:  Uncaught Exception: Serialization of 'Closure' is not allowed in /home/cloudpanel/htdocs/www.humaxdirect.co.uk/vendor/magento/framework/Session/SessionManager.php:139`
