### PR TITLE
Replace deprecated Zend_Http_* objects with laminas-http equivalents

### DIFF
--- a/Controller/Adminhtml/CodistoController.php
+++ b/Controller/Adminhtml/CodistoController.php
@@ -108,10 +108,10 @@ class CodistoController extends \Magento\Backend\App\Action
                 $curlOptions = [CURLOPT_TIMEOUT => 60, CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_0];
 
                 // impossible to use the object manager because di on non-namespaced classes is broken
-                $client = new \Zend_Http_Client( // @codingStandardsIgnoreLine MEQP2.Classes.ObjectInstantiation.FoundDirectInstantiation
+                $client = new \Laminas\Http\Client( // @codingStandardsIgnoreLine MEQP2.Classes.ObjectInstantiation.FoundDirectInstantiation
                     'https://ui.codisto.com/create',
                     [
-                        'adapter' => 'Zend_Http_Client_Adapter_Curl',
+                        'adapter' => '\Laminas\Http\Client\Adapter\Curl',
                         'curloptions' => $curlOptions,
                         'keepalive' => false,
                         'strict' => false,
@@ -200,10 +200,10 @@ class CodistoController extends \Magento\Backend\App\Action
             $curlOptions = [ CURLOPT_TIMEOUT => 60, CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_0 ];
 
             // impossible to use the object manager because di on non-namespaced classes is broken
-            $client = new \Zend_Http_Client( // @codingStandardsIgnoreLine MEQP2.Classes.ObjectInstantiation.FoundDirectInstantiation
+            $client = new \Laminas\Http\Client( // @codingStandardsIgnoreLine MEQP2.Classes.ObjectInstantiation.FoundDirectInstantiation
                 'https://ui.codisto.com/create',
                 [
-                    'adapter' => 'Zend_Http_Client_Adapter_Curl',
+                    'adapter' => '\Laminas\Http\Client\Adapter\Curl',
                     'curloptions' => $curlOptions,
                     'keepalive' => false,
                     'strict' => false,

--- a/Controller/CodistoActionInstance.php
+++ b/Controller/CodistoActionInstance.php
@@ -384,10 +384,10 @@ class CodistoActionInstance extends \Magento\Backend\App\AbstractAction
             $adminBasePath . '/codisto/ebaytab/'.$storeId.'/'.$merchant['merchantid'].'/';
 
         // use Zend_Http_Client directly to have discrete control over compression, http version and keep alive
-        $client = new \Zend_Http_Client( // @codingStandardsIgnoreLine MEQP2.Classes.ObjectInstantiation.FoundDirectInstantiation
+        $client = new \Laminas\Http\Client( // @codingStandardsIgnoreLine MEQP2.Classes.ObjectInstantiation.FoundDirectInstantiation
             $remoteUrl,
             [
-                'adapter' => 'Zend_Http_Client_Adapter_Curl',
+                'adapter' => '\Laminas\Http\Client\Adapter\Curl',
                 'curloptions' => $curlOptions,
                 'keepalive' => false,
                 'strict' => false,

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -282,10 +282,10 @@ class Data
             $this->registerProductChanges($merchants, $eventtype, $productids);
 
             if (!$this->client) {
-                $this->client = new \Zend_Http_Client(); // @codingStandardsIgnoreLine MEQP2.Classes.ObjectInstantiation.FoundDirectInstantiation
+                $this->client = new \\Laminas\Http\Client(); // @codingStandardsIgnoreLine MEQP2.Classes.ObjectInstantiation.FoundDirectInstantiation
                 $this->client->setConfig(
                     [
-                        'adapter' => 'Zend_Http_Client_Adapter_Curl',
+                        'adapter' => '\Laminas\Http\Client\Adapter\Curl',
                         'curloptions' =>
                         [
                             CURLOPT_TIMEOUT => 4,

--- a/Helper/Signal.php
+++ b/Helper/Signal.php
@@ -55,10 +55,10 @@ if (getenv('CURL_CA_BUNDLE')) { // @codingStandardsIgnoreLine
 }
 
 // using zend http client directly in sub process
-$client = new \Zend_Http_Client(); // @codingStandardsIgnoreLine
+$client = new \Laminas\Http\Client(); // @codingStandardsIgnoreLine
 $client->setConfig(
     [
-        'adapter' => 'Zend_Http_Client_Adapter_Curl',
+        'adapter' => '\Laminas\Http\Client\Adapter\Curl',
         'curloptions' => $curlOptions,
         'keepalive' => true,
         'maxredirects' => 0


### PR DESCRIPTION
Magento 2.4.6 removes support for Zend_Http and replaces it with laminas-http package instead.

This PR is backwards compatible with Magento 2.3.5 onward.